### PR TITLE
Adds guestos and uuids methods.

### DIFF
--- a/lib/fission/vm.rb
+++ b/lib/fission/vm.rb
@@ -349,7 +349,8 @@ module Fission
       os_pattern = /\"(.*)\"$/
 
       File.open conf_file_response.data, 'r' do |f|
-        guestos = f.grep(guestos_pattern)[0].scan(os_pattern).flatten[0]
+        guestos_line = f.grep(guestos_pattern)[0] || ''
+        guestos = guestos_line.scan(os_pattern).flatten[0] || ''
         response.data = guestos
       end
 
@@ -386,8 +387,8 @@ module Fission
         f.grep(uuid_pattern).each do |line|
            location = line.scan(location_pattern).flatten[0] || bios = line.scan(bios_pattern).flatten[0]
         end
-        response.data['bios'] = bios
-        response.data['location'] = location
+        response.data['bios'] = bios unless bios.empty?
+        response.data['location'] = location unless location.empty?
       end
 
       response

--- a/lib/fission/vm.rb
+++ b/lib/fission/vm.rb
@@ -377,8 +377,8 @@ module Fission
       response = Response.new :code => 0, :data => {}
 
       uuid_pattern = /^uuid(?!\.action)/
-      bios_pattern = /bios\W=\W"(.*)"$/
-      location_pattern = /location\W=\W"(.*)"$/
+      bios_pattern = /bios\W*=\W*"(.*)"$/
+      location_pattern = /location\W*=\W*"(.*)"$/
 
       File.open conf_file_response.data, 'r' do |f|
         bios = ''

--- a/spec/fission/vm_spec.rb
+++ b/spec/fission/vm_spec.rb
@@ -581,6 +581,107 @@ ethernet1.generatedAddressenable = "TRUE"'
     end
   end
 
+  describe 'guestos' do
+    before do
+      @conf_file_response_mock.stub_as_successful @conf_file_path
+
+      @vm.should_receive(:conf_file).and_return(@conf_file_response_mock)
+      @conf_file_io = StringIO.new
+    end
+
+    it 'should return a successful response with a string when a guestos is defined' do
+      @conf_file_response_mock.stub_as_successful @conf_file_path
+
+      vmx_content = 'vmci0.present = "TRUE"
+roamingVM.exitBehavior = "go"
+tools.syncTime = "TRUE"
+displayName = "sample-debian"
+guestOS = "debian5"
+nvram = "sample-debian.nvram"
+virtualHW.productCompatibility = "hosted"
+printers.enabled = "FALSE"
+proxyApps.publishToHost = "FALSE"
+tools.upgrade.policy = "upgradeAtPowerCycle"'
+
+      @conf_file_io.string = vmx_content
+
+      File.should_receive(:open).with(@conf_file_path, 'r').and_yield(@conf_file_io)
+
+      response = @vm.guestos
+      response.should be_a_successful_response
+      response.data.should == 'debian5'
+    end
+
+    it 'should return a successful response with no data if no guestos defined' do
+
+      vmx_content = 'vmci0.present = "TRUE"
+roamingVM.exitBehavior = "go"
+tools.syncTime = "TRUE"
+nvram = "sample-debian.nvram"
+virtualHW.productCompatibility = "hosted"
+printers.enabled = "FALSE"
+proxyApps.publishToHost = "FALSE"
+tools.upgrade.policy = "upgradeAtPowerCycle"'
+
+      @conf_file_io.string = vmx_content
+
+      File.should_receive(:open).with(@conf_file_path, 'r').and_yield(@conf_file_io)
+
+      response = @vm.guestos
+      response.should be_a_successful_response
+      response.data.should == ''
+    end
+  end
+
+  describe 'uuids' do
+    before do
+      @conf_file_response_mock.stub_as_successful @conf_file_path
+
+      @vm.should_receive(:conf_file).and_return(@conf_file_response_mock)
+      @conf_file_io = StringIO.new
+    end
+
+    it 'should return a successful response with a hash when uuids are defined' do
+      @conf_file_response_mock.stub_as_successful @conf_file_path
+
+      vmx_content = 'extendedConfigFile = "sample-debian.vmxf"
+checkpoint.vmState = ""
+uuid.location = "56 4d d8 9c f8 ec 95 73-2e ea a0 f3 7a 1d 6f c8"
+uuid.bios = "56 4d d8 9c f8 ec 95 73-2e ea a0 f3 7a 1d 6f c8"
+cleanShutdown = "TRUE"
+replay.supported = "TRUE"
+replay.filename = ""
+scsi0:0.redo = ""'
+
+      @conf_file_io.string = vmx_content
+
+      File.should_receive(:open).with(@conf_file_path, 'r').and_yield(@conf_file_io)
+
+      response = @vm.uuids
+      response.should be_a_successful_response
+      response.data.should == { 'bios'     => '56 4d d8 9c f8 ec 95 73-2e ea a0 f3 7a 1d 6f c8',
+                                'location' => '56 4d d8 9c f8 ec 95 73-2e ea a0 f3 7a 1d 6f c8' }
+    end
+
+    it 'should return a successful response with empty hash if no uuids are defined' do
+
+      vmx_content = 'extendedConfigFile = "sample-debian.vmxf"
+checkpoint.vmState = ""
+cleanShutdown = "TRUE"
+replay.supported = "TRUE"
+replay.filename = ""
+scsi0:0.redo = ""'
+
+      @conf_file_io.string = vmx_content
+
+      File.should_receive(:open).with(@conf_file_path, 'r').and_yield(@conf_file_io)
+
+      response = @vm.uuids
+      response.should be_a_successful_response
+      response.data.should == {}
+    end
+  end
+
   describe 'path' do
     it 'should return the path of the VM' do
       vm_path = File.join(Fission.config['vm_dir'], 'foo.vmwarevm').gsub '\\', ''


### PR DESCRIPTION
This patch adds two methods for data mining the vmx file.  Both
  methods operate is a similar fashion as network_info.  Patch does not
  include test coverage.
