### PR TITLE
Makes the find_by_mac_address return last match.

### DIFF
--- a/lib/fission/lease.rb
+++ b/lib/fission/lease.rb
@@ -97,7 +97,7 @@ module Fission
 
       if all_response.successful?
         response = Response.new :code => 0
-        response.data = all_response.data.find { |l| l.mac_address == mac_address }
+        response.data = all_response.data.find_all { |l| l.mac_address == mac_address }.last
       else
         response = all_response
       end


### PR DESCRIPTION
This patch makes it so that Fission::Lease.find_by_mac_address returns
  the last match from the leases file rather than the first.  This is
  being done because when Fusion delves out ip addresses the last
  instance of of the mac address in the file wins.
