### PR TITLE
Fix lease return logic.

### DIFF
--- a/lib/fission/lease.rb
+++ b/lib/fission/lease.rb
@@ -97,7 +97,7 @@ module Fission
 
       if all_response.successful?
         response = Response.new :code => 0
-        response.data = all_response.data.find_all { |l| l.mac_address == mac_address }.last
+        response.data = all_response.data.find_all { |l| l.mac_address == mac_address }.sort_by { |l| l.end }.last
       else
         response = all_response
       end


### PR DESCRIPTION
Identified that the logic that the last lease in the file wins when
  it is actually the last lease to expire.  This requires we sort the
  list of end times and select that last one.
