### PR TITLE
Update reference to CFProperty so libxml is not forced upon users of fission

### DIFF
--- a/fission.gemspec
+++ b/fission.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.add_dependency 'CFPropertyList', '~> 2.0.17'
+  s.add_dependency 'CFPropertyList', '~> 2.1.1'
   s.add_development_dependency 'rspec', '~> 2.8.0'
   s.add_development_dependency 'fakefs', '~> 0.3.2'
 end


### PR DESCRIPTION
Fixing this will allow veewee to run on windows jruby boxes.
