### PR TITLE
Add license to gemspec

### DIFF
--- a/fission.gemspec
+++ b/fission.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/thbishop/fission"
   s.summary     = %q{Command line tool to manage VMware Fusion VMs}
   s.description = %q{A simple utility to manage VMware Fusion VMs from the command line}
+  s.license     = 'MIT'
 
   s.rubyforge_project = "fission"
 


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.
